### PR TITLE
Correction to handling of anonymous identifiers.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,21 +51,27 @@ FullStory.prototype.loaded = function() {
 };
 
 /**
- * Identify.
+ * Identify.  But, use FS.setUserVars if we only have an anonymous id, keeping the
+ * user id unbound until we (hopefully) get a login page or similar and another call
+ * to identify with more useful contents.  (This because FullStory doesn't like the
+ * user id changing once set.)
  *
  * @param {Identify} identify
  */
 
 FullStory.prototype.identify = function(identify) {
-  var id = identify.userId() || identify.anonymousId();
   var traits = identify.traits({ name: 'displayName' });
 
   var newTraits = foldl(function(results, value, key) {
     if (key !== 'id') results[key === 'displayName' || key === 'email' ? key : convert(key, value)] = value;
     return results;
   }, {}, traits);
-
-  window.FS.identify(String(id), newTraits);
+  if (identify.userId()) {
+    window.FS.identify(String(identify.userId()), newTraits);
+  } else {
+    newTraits.Analytics_AnonymousId_str = String(identify.anonymousId());
+    window.FS.setUserVars(newTraits);
+  }
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -68,7 +68,7 @@ describe('FullStory', function() {
 
       it('should default to anonymousId', function() {
         analytics.identify();
-        analytics.called(window.FS.identify);
+        analytics.called(window.FS.setUserVars);
       });
 
       it('should only send strings as the id', function() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,7 @@ describe('FullStory', function() {
     describe('#identify', function() {
       beforeEach(function() {
         analytics.stub(window.FS, 'identify');
+        analytics.stub(window.FS, 'setUserVars');
       });
 
       it('should default to anonymousId', function() {


### PR DESCRIPTION
FullStory expects at most one userid to be associated with the cookie marking a session.
Segment separates "anonymous" ids (useful for a shared handle across multiple tools, so
FullStory and anything else agree what to call an anonymous user) and "user" ids, and
you could start anonymous and become recognized.  This change supports that transition by
not putting the anonymous ID into the user ID slot; instead, anonymous usage relies only
on FS.setUserVars and a new custom variable for the (most recent, if there are several)
anonymous id.